### PR TITLE
Lio files list

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -8,9 +8,11 @@ use Console\App\Commands\AppsDescribeCommand;
 use Console\App\Commands\AppsListCommand;
 use Console\App\Commands\AuthCommand;
 use GuzzleHttp\Client;
+use Console\App\Commands\FilesListCommand;
 
 $app = new Application();
 $app->add(new AppsListCommand(new Client()));
 $app->add(new AppsDescribeCommand(new Client()));
 $app->add(new AuthCommand());
+$app->add(new FilesListCommand(new Client()));
 $app->run();

--- a/src/App/Commands/FilesListCommand.php
+++ b/src/App/Commands/FilesListCommand.php
@@ -12,64 +12,86 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class FilesListCommand extends Command
 {
-    const API_ENDPOINT = 'https://api.lamp.io/apps/{app_name}/files';
+	const API_ENDPOINT = 'https://api.lamp.io/apps/{app_name}/files';
 
-    const RESPONSE_FORMAT_TYPES = [
-        'json' => [
-            'AcceptHeader' => 'Accept: application/vnd.api+json',
-        ],
-        'gzip' => [
-            'AcceptHeader' => 'Accept: application/x-gzip',
-        ],
-        'zip'  => [
-            'AcceptHeader' => 'Accept: application/zip',
-        ],
-    ];
+	const RESPONSE_FORMAT_TYPES = [
+		'json' => [
+			'AcceptHeader' => 'Accept: application/vnd.api+json',
+		],
+		'gzip' => [
+			'AcceptHeader' => 'Accept: application/x-gzip',
+		],
+		'zip'  => [
+			'AcceptHeader' => 'Accept: application/zip',
+		],
+	];
 
-    protected static $defaultName = 'files:list';
+	protected static $defaultName = 'files:list';
 
-    protected function configure()
-    {
-        $this->setDescription('Return files from the root of an app')
-            ->setHelp('try rebooting')
-            ->addArgument('app_id', InputArgument::REQUIRED, 'From which app_id need to get fiels?')
-            ->addOption('path', 'p', InputOption::VALUE_REQUIRED, 'Path where will be stored received data list. Dont forget that this path should has write permissions', '')
-            ->addOption('json', 'j', InputOption::VALUE_NONE, 'Set this flag, if you want response as a json')
-            ->addOption('gzip', 'g', InputOption::VALUE_NONE, 'Set this flag, if you want response as a gzip archive')
-            ->addOption('zip', 'z', InputOption::VALUE_NONE, 'Set this flag, if you want response as a zip archive.');
-    }
+	/**
+	 *
+	 */
+	protected function configure()
+	{
+		$this->setDescription('Return files from the root of an app')
+			->setHelp('try rebooting')
+			->addArgument('app_id', InputArgument::REQUIRED, 'From which app_id need to get fiels?')
+			->addOption('json', 'j', InputOption::VALUE_NONE, 'Set this flag, if you want response as a json')
+			->addOption('gzip', 'g', InputOption::VALUE_NONE, 'Set this flag, if you want response as a gzip archive')
+			->addOption('zip', 'z', InputOption::VALUE_NONE, 'Set this flag, if you want response as a zip archive.');
+	}
 
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
-        parent::execute($input, $output);
-        $format = $this->getResponseFormat($input);
-        try {
-            $this->httpHelper->getClient()->request(
-                'GET',
-                str_replace('{app_name}', $input->getArgument('app_id'), self::API_ENDPOINT),
-                [
-                    'headers' => array_merge($this->httpHelper->getHeaders(), ['Accept' => self::RESPONSE_FORMAT_TYPES[$format]['AcceptHeader']]),
-                    'sink' => fopen($input->getOption('path') . 'lamp.' . $format, 'w'),
-                ]
-            );
-            $output->writeln('File received, ' . $input->getOption('path') . 'lamp.' . $format);
-        } catch (GuzzleException $guzzleException) {
-            $output->writeln($guzzleException->getMessage());
-            die();
-        }
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int|null|void
+	 * @throws \Exception
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output)
+	{
+		parent::execute($input, $output);
+		$format = $this->getResponseFormat($input);
+		try {
+			$this->httpHelper->getClient()->request(
+				'GET',
+				str_replace('{app_name}', $input->getArgument('app_id'), self::API_ENDPOINT),
+				[
+					'headers' => array_merge($this->httpHelper->getHeaders(), ['Accept' => self::RESPONSE_FORMAT_TYPES[$format]['AcceptHeader']]),
+					'sink'    => fopen($this->getPath('lamp') . '.' . $format, 'w'),
+				]
+			);
+			$output->writeln('File received, ' . $this->getPath('lamp') . '.' . $format);
+		} catch (GuzzleException $guzzleException) {
+			$output->writeln($guzzleException->getMessage());
+			die();
+		}
 
-    }
+	}
 
-    protected function getResponseFormat(InputInterface $input): string
-    {
-        $format = 'json';
-        foreach ($input->getOptions() as $key => $option) {
-            if (array_key_exists($key, self::RESPONSE_FORMAT_TYPES) && !empty($option)) {
-                $format = $key;
-            }
-        }
-        return $format;
-    }
+	/**
+	 * @param string $fileName
+	 * @return string
+	 */
+	protected function getPath(string $fileName): string
+	{
+		return getenv('HOME') . getenv("HOMEDRIVE") . getenv("HOMEPATH") . DIRECTORY_SEPARATOR . '.config' . DIRECTORY_SEPARATOR . '.lamp.io/' . $fileName;
+	}
+
+
+	/**
+	 * @param InputInterface $input
+	 * @return string
+	 */
+	protected function getResponseFormat(InputInterface $input): string
+	{
+		$format = 'json';
+		foreach ($input->getOptions() as $key => $option) {
+			if (array_key_exists($key, self::RESPONSE_FORMAT_TYPES) && !empty($option)) {
+				$format = $key;
+			}
+		}
+		return $format;
+	}
 
 
 }

--- a/src/App/Commands/FilesListCommand.php
+++ b/src/App/Commands/FilesListCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+
+namespace Console\App\Commands;
+
+
+use GuzzleHttp\Exception\GuzzleException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FilesListCommand extends Command
+{
+    const API_ENDPOINT = 'https://api.lamp.io/apps/{app_name}/files';
+
+    const RESPONSE_FORMAT_TYPES = [
+        'json' => [
+            'AcceptHeader' => 'Accept: application/vnd.api+json',
+        ],
+        'gzip' => [
+            'AcceptHeader' => 'Accept: application/x-gzip',
+        ],
+        'zip'  => [
+            'AcceptHeader' => 'Accept: application/zip',
+        ],
+    ];
+
+    protected static $defaultName = 'files:list';
+
+    protected function configure()
+    {
+        $this->setDescription('Return files from the root of an app')
+            ->setHelp('try rebooting')
+            ->addArgument('app_id', InputArgument::REQUIRED, 'From which app_id need to get fiels?')
+            ->addOption('path', 'p', InputOption::VALUE_REQUIRED, 'Path where will be stored received data list. Dont forget that this path should has write permissions', '')
+            ->addOption('json', 'j', InputOption::VALUE_NONE, 'Set this flag, if you want response as a json')
+            ->addOption('gzip', 'g', InputOption::VALUE_NONE, 'Set this flag, if you want response as a gzip archive')
+            ->addOption('zip', 'z', InputOption::VALUE_NONE, 'Set this flag, if you want response as a zip archive.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        parent::execute($input, $output);
+        $format = $this->getResponseFormat($input);
+        try {
+            $this->httpHelper->getClient()->request(
+                'GET',
+                str_replace('{app_name}', $input->getArgument('app_id'), self::API_ENDPOINT),
+                [
+                    'headers' => array_merge($this->httpHelper->getHeaders(), ['Accept' => self::RESPONSE_FORMAT_TYPES[$format]['AcceptHeader']]),
+                    'sink' => fopen($input->getOption('path') . 'lamp.' . $format, 'w'),
+                ]
+            );
+            $output->writeln('File received, ' . $input->getOption('path') . 'lamp.' . $format);
+        } catch (GuzzleException $guzzleException) {
+            $output->writeln($guzzleException->getMessage());
+            die();
+        }
+
+    }
+
+    protected function getResponseFormat(InputInterface $input): string
+    {
+        $format = 'json';
+        foreach ($input->getOptions() as $key => $option) {
+            if (array_key_exists($key, self::RESPONSE_FORMAT_TYPES) && !empty($option)) {
+                $format = $key;
+            }
+        }
+        return $format;
+    }
+
+
+}

--- a/src/App/Commands/FilesListCommand.php
+++ b/src/App/Commands/FilesListCommand.php
@@ -36,6 +36,8 @@ class FilesListCommand extends Command
 
 	protected static $defaultName = 'files:list';
 
+	protected $counter = 0;
+
 	/**
 	 *
 	 */
@@ -45,6 +47,7 @@ class FilesListCommand extends Command
 			->setHelp('try rebooting')
 			->addArgument('app_id', InputArgument::REQUIRED, 'From which app_id need to get fields?')
 			->addArgument('file_id', InputArgument::OPTIONAL, 'The ID of the file. The ID is also the file path relative to its app root.', '/')
+			->addOption('limit', 'l', InputOption::VALUE_REQUIRED, ' The number of results to return in each response to a list operation. The default value is 1000 (the maximum allowed). Using a lower value may help if an operation times out', '1000')
 			->addOption('human-readable', '', InputOption::VALUE_NONE, 'Format size values from raw bytes to human readable format')
 			->addOption('recursive', 'r', InputOption::VALUE_NONE, 'Command is performed on all files or objects under the specified path')
 			->addOption('gzip', 'g', InputOption::VALUE_NONE, 'Set this flag, if you want response as a gzip archive')
@@ -93,6 +96,9 @@ class FilesListCommand extends Command
 	 */
 	protected function prepareOutput(InputInterface $input, Table $table, string $filePath)
 	{
+		if ($this->counter == $input->getOption('limit')) {
+			return;
+		}
 		$response = $this->sendRequest(
 			self::DEFAULT_FORMAT,
 			$input->getArgument('app_id'),
@@ -118,6 +124,7 @@ class FilesListCommand extends Command
 				$val['attributes'],
 				$input->getOption('human-readable')
 			)));
+			$this->counter += 1;
 			if ($val['attributes']['is_dir'] && !empty($input->getOption('recursive'))) {
 				$this->prepareOutput($input, $table, $val['id']);
 			}

--- a/src/App/Commands/FilesListCommand.php
+++ b/src/App/Commands/FilesListCommand.php
@@ -172,11 +172,16 @@ class FilesListCommand extends Command
 	 * @param int $precision
 	 * @return string
 	 */
-	protected function formatBytes(int $bytes, int $precision = 2)
+	protected function formatBytes(int $bytes, int $precision = 2): string
 	{
-		$unit = ['B', 'KB', 'MB', 'GB', 'TB'];
+		$unit = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
 		$exp = floor(log($bytes, 1024)) | 0;
-		return round($bytes / (pow(1024, $exp)), $precision) . $unit[$exp];
+		if (empty($unit[$exp])) {
+			$result = (string)$bytes;
+		} else {
+			$result = round($bytes / (pow(1024, $exp)), $precision) . $unit[$exp];
+		}
+		return $result;
 	}
 
 
@@ -184,7 +189,7 @@ class FilesListCommand extends Command
 	 * @param string $format
 	 * @return array
 	 */
-	protected function getRequestOptions(string $format)
+	protected function getRequestOptions(string $format): array
 	{
 		return array_merge([
 			'headers' => array_merge($this->httpHelper->getHeaders(), ['Accept' => self::RESPONSE_FORMAT_TYPES[$format]['AcceptHeader']]),

--- a/src/App/Commands/FilesListCommand.php
+++ b/src/App/Commands/FilesListCommand.php
@@ -22,6 +22,8 @@ class FilesListCommand extends Command
 
 	const DEFAULT_FORMAT = 'json';
 
+	const MAX_LIMIT = '1000';
+
 	const RESPONSE_FORMAT_TYPES = [
 		'json' => [
 			'AcceptHeader' => 'Accept: application/vnd.api+json',
@@ -47,7 +49,7 @@ class FilesListCommand extends Command
 			->setHelp('try rebooting')
 			->addArgument('app_id', InputArgument::REQUIRED, 'From which app_id need to get fields?')
 			->addArgument('file_id', InputArgument::OPTIONAL, 'The ID of the file. The ID is also the file path relative to its app root.', '/')
-			->addOption('limit', 'l', InputOption::VALUE_REQUIRED, ' The number of results to return in each response to a list operation. The default value is 1000 (the maximum allowed). Using a lower value may help if an operation times out', '1000')
+			->addOption('limit', 'l', InputOption::VALUE_REQUIRED, ' The number of results to return in each response to a list operation. The default value is 1000 (the maximum allowed). Using a lower value may help if an operation times out', self::MAX_LIMIT)
 			->addOption('human-readable', '', InputOption::VALUE_NONE, 'Format size values from raw bytes to human readable format')
 			->addOption('recursive', 'r', InputOption::VALUE_NONE, 'Command is performed on all files or objects under the specified path')
 			->addOption('gzip', 'g', InputOption::VALUE_NONE, 'Set this flag, if you want response as a gzip archive')
@@ -96,7 +98,7 @@ class FilesListCommand extends Command
 	 */
 	protected function prepareOutput(InputInterface $input, Table $table, string $filePath)
 	{
-		if ($this->counter == $input->getOption('limit')) {
+		if ($this->counter == $input->getOption('limit') || $this->counter == self::MAX_LIMIT) {
 			return;
 		}
 		$response = $this->sendRequest(

--- a/src/App/Commands/FilesListCommand.php
+++ b/src/App/Commands/FilesListCommand.php
@@ -74,7 +74,7 @@ class FilesListCommand extends Command
 	 */
 	protected function getPath(string $fileName): string
 	{
-		return getenv('HOME') . getenv("HOMEDRIVE") . getenv("HOMEPATH") . DIRECTORY_SEPARATOR . '.config' . DIRECTORY_SEPARATOR . '.lamp.io/' . $fileName;
+		return getenv('HOME') . getenv("HOMEDRIVE") . getenv("HOMEPATH") . DIRECTORY_SEPARATOR . '.config' . DIRECTORY_SEPARATOR . 'lamp.io/' . $fileName;
 	}
 
 

--- a/src/App/Commands/FilesListCommand.php
+++ b/src/App/Commands/FilesListCommand.php
@@ -4,15 +4,23 @@
 namespace Console\App\Commands;
 
 
+use Art4\JsonApiClient\Exception\ValidationException;
 use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Art4\JsonApiClient\Helper\Parser;
+use Art4\JsonApiClient\V1\Document;
+use Art4\JsonApiClient\Serializer\ArraySerializer;
 
 class FilesListCommand extends Command
 {
 	const API_ENDPOINT = 'https://api.lamp.io/apps/%s/files/%s';
+
+	const DEFAULT_FORMAT = 'json';
 
 	const RESPONSE_FORMAT_TYPES = [
 		'json' => [
@@ -37,6 +45,7 @@ class FilesListCommand extends Command
 			->setHelp('try rebooting')
 			->addArgument('app_id', InputArgument::REQUIRED, 'From which app_id need to get fields?')
 			->addArgument('file_id', InputArgument::OPTIONAL, 'The ID of the file. The ID is also the file path relative to its app root.', '/')
+			->addOption('human-readable', '', InputOption::VALUE_NONE, 'Format size values from raw bytes to human readable format')
 			->addOption('gzip', 'g', InputOption::VALUE_NONE, 'Set this flag, if you want response as a gzip archive')
 			->addOption('zip', 'z', InputOption::VALUE_NONE, 'Set this flag, if you want response as a zip archive.');
 	}
@@ -52,26 +61,78 @@ class FilesListCommand extends Command
 		parent::execute($input, $output);
 		$format = $this->getResponseFormat($input);
 		try {
-			$response = $this->httpHelper->getClient()->request(
-				'GET',
-				sprintf(self::API_ENDPOINT,
-					$input->getArgument('app_id'),
-					urlencode($input->getArgument('file_id'))
-				),
-				$this->getRequestOptions($format)
-			);
-			$output->writeln('<info>File received, ' . $this->getPath('lamp') . '.' . $format . '</info>');
+			$response = $this->sendRequest($format, $input);
+			if ($format != self::DEFAULT_FORMAT) {
+				$output->writeln('<info>File received, ' . $this->getPath('lamp') . '.' . $format . '</info>');
+
+			} else {
+				/** @var Document $document */
+				$document = Parser::parseResponseString($response->getBody()->getContents());
+				$serializer = new ArraySerializer(['recursive' => true]);
+				$table = new Table($output);
+				$table->setStyle('compact');
+				foreach ($serializer->serialize($document->get('included')) as $key => $val) {
+					if (empty($val['relationships'])) {
+						continue;
+					}
+					$table->addRow(explode(' ', $this->formatFileInfo(
+						$val['id'],
+						$val['attributes'],
+						$input->getOption('human-readable')
+					)));
+
+				}
+				$table->render();
+
+			}
 		} catch (GuzzleException $guzzleException) {
 			$output->writeln($guzzleException->getMessage());
+		} catch (ValidationException $validationException) {
+			$output->writeln('<error>' . $validationException->getMessage() . '</error>');
 		}
 
 	}
+
+	/**
+	 * @param string $format
+	 * @param InputInterface $input
+	 * @return \Psr\Http\Message\ResponseInterface
+	 * @throws GuzzleException
+	 */
+	protected function sendRequest(string $format, InputInterface $input): ResponseInterface
+	{
+		return $this->httpHelper->getClient()->request(
+			'GET',
+			sprintf(self::API_ENDPOINT,
+				$input->getArgument('app_id'),
+				urlencode($input->getArgument('file_id'))
+			),
+			$this->getRequestOptions($format)
+		);
+
+
+	}
+
+	protected function formatFileInfo(string $fileName, array $fileAttributes, bool $isHumanReadable = true): string
+	{
+		$date = date('Y-m-d H:i:s', strtotime($fileAttributes['modify_time']));
+		$size = $isHumanReadable ? $this->formatBytes($fileAttributes['size']) : $fileAttributes['size'];
+		return $date . '  ' . $size . '  ' . $fileName;
+	}
+
+	protected function formatBytes(int $bytes, int $precision = 2)
+	{
+		$unit = ['B', 'KB', 'MB', 'GB', 'TB'];
+		$exp = floor(log($bytes, 1024)) | 0;
+		return round($bytes / (pow(1024, $exp)), $precision) . $unit[$exp];
+	}
+
 
 	protected function getRequestOptions(string $format)
 	{
 		return array_merge([
 			'headers' => array_merge($this->httpHelper->getHeaders(), ['Accept' => self::RESPONSE_FORMAT_TYPES[$format]['AcceptHeader']]),
-		], $format != 'json' ? ['sink' => fopen($this->getPath('lamp') . '.' . $format, 'w')] : []);
+		], $format != self::DEFAULT_FORMAT ? ['sink' => fopen($this->getPath('lamp') . '.' . $format, 'w')] : []);
 	}
 
 
@@ -91,7 +152,7 @@ class FilesListCommand extends Command
 	 */
 	protected function getResponseFormat(InputInterface $input): string
 	{
-		$format = 'json';
+		$format = self::DEFAULT_FORMAT;
 		foreach ($input->getOptions() as $key => $option) {
 			if (array_key_exists($key, self::RESPONSE_FORMAT_TYPES) && !empty($option)) {
 				$format = $key;

--- a/src/App/Commands/FilesListCommand.php
+++ b/src/App/Commands/FilesListCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class FilesListCommand extends Command
 {
-	const API_ENDPOINT = 'https://api.lamp.io/apps/{app_id}/files';
+	const API_ENDPOINT = 'https://api.lamp.io/apps/%s/files/%s';
 
 	const RESPONSE_FORMAT_TYPES = [
 		'json' => [
@@ -36,7 +36,7 @@ class FilesListCommand extends Command
 		$this->setDescription('Return files from the root of an app')
 			->setHelp('try rebooting')
 			->addArgument('app_id', InputArgument::REQUIRED, 'From which app_id need to get fields?')
-			->addOption('level', 'l', InputOption::VALUE_NONE, 'Work only if you dont set, any other options, it will define depth of the directory tree')
+			->addArgument('file_id', InputArgument::OPTIONAL, 'The ID of the file. The ID is also the file path relative to its app root.', '/')
 			->addOption('gzip', 'g', InputOption::VALUE_NONE, 'Set this flag, if you want response as a gzip archive')
 			->addOption('zip', 'z', InputOption::VALUE_NONE, 'Set this flag, if you want response as a zip archive.');
 	}
@@ -54,7 +54,10 @@ class FilesListCommand extends Command
 		try {
 			$response = $this->httpHelper->getClient()->request(
 				'GET',
-				str_replace('{app_id}', $input->getArgument('app_id'), self::API_ENDPOINT),
+				sprintf(self::API_ENDPOINT,
+					$input->getArgument('app_id'),
+					urlencode($input->getArgument('file_id'))
+				),
 				$this->getRequestOptions($format)
 			);
 			$output->writeln('<info>File received, ' . $this->getPath('lamp') . '.' . $format . '</info>');

--- a/src/App/Commands/FilesListCommand.php
+++ b/src/App/Commands/FilesListCommand.php
@@ -60,7 +60,7 @@ class FilesListCommand extends Command
 					'sink'    => fopen($this->getPath('lamp') . '.' . $format, 'w'),
 				]
 			);
-			$output->writeln('File received, ' . $this->getPath('lamp') . '.' . $format);
+			$output->writeln('<info>File received, ' . $this->getPath('lamp') . '.' . $format . '</info>');
 		} catch (GuzzleException $guzzleException) {
 			$output->writeln($guzzleException->getMessage());
 			die();


### PR DESCRIPTION
Hi, 
The issue https://github.com/lamp-io/lio/issues/4

Please take a look on this pull request, after my first pull request (https://github.com/lamp-io/lio/pull/7). It includes all changes from this one.

I've added implementation of files:list [options] {app_id},  command. Please take a look on files:list --help, to see all options.
The command will download file (in json/zip/gzip formats, depends on which option user will set, if options wasnt set the default format will be .json)
After file will be downloaded, user will get output `File received, $HOME/.config/.lamp.io/lamp.json`. 

