### PR TITLE
put lio in my path somehow

### DIFF
--- a/bin/lio
+++ b/bin/lio
@@ -1,7 +1,10 @@
 #!/usr/bin/env php
 <?php
-
-require_once __DIR__ . '/../vendor/autoload.php';
+if (file_exists(dirname(__DIR__, 3) . '/autoload.php')) {
+    require_once dirname(__DIR__, 3) . '/autoload.php';
+} else {
+    require_once dirname(__DIR__) . '/vendor/autoload.php';
+}
 
 use Symfony\Component\Console\Application;
 use Console\App\Commands\AppsDescribeCommand;

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,11 @@
 {
+  "name": "lamp-io/lio",
+  "type": "library",
+  "description": "Command line interface, for lamp.io platform",
+  "authors": [],
+  "bin": [
+    "bin/lio"
+  ],
   "require": {
     "symfony/console": "^4.3",
     "art4/json-api-client": "^0.10.0",
@@ -6,6 +13,7 @@
     "php": ">=7.0",
     "ext-json": "*"
   },
+  "version": "0.1.0 - ALPHA",
   "autoload": {
     "psr-4": {
       "Console\\": "src"

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "lamp-io/lio",
   "type": "library",
   "description": "Command line interface, for lamp.io platform",
+  "license": [],
   "authors": [],
   "bin": [
     "bin/lio"


### PR DESCRIPTION
Hi, 

https://github.com/lamp-io/lio/issues/11

I've added settings to composer, that will allow to install it as a global package. 
And one more moment, i've left authors field in composer setting as empty, so you can set required mails or give me it and i will do it. And same related to license field.

(more details how to test and set up it, i will write in linked issue)