### PR TITLE
Output json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "symfony/finder": "^4.3",
     "padraic/phar-updater": "^1.0.6"
   },
-  "version": "0.1.0 - ALPHA",
+  "version": "0.1.0",
   "autoload": {
     "psr-4": {
       "Console\\": "src"

--- a/src/App/Commands/AppsDescribeCommand.php
+++ b/src/App/Commands/AppsDescribeCommand.php
@@ -3,7 +3,6 @@
 namespace Console\App\Commands;
 
 use Art4\JsonApiClient\V1\Document;
-use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -56,7 +55,7 @@ class AppsDescribeCommand extends Command
 
 		try {
 			if (!empty($input->getOption('json'))) {
-				$output->writeln($this->getOutputAsJson($response));
+				$output->writeln($response->getBody()->getContents());
 			} else {
 				/** @var Document $document */
 				$document = Parser::parseResponseString($response->getBody()->getContents());
@@ -69,6 +68,11 @@ class AppsDescribeCommand extends Command
 		}
 	}
 
+	/**
+	 * @param Document $document
+	 * @param Table $table
+	 * @return Table
+	 */
 	protected function getOutputAsTable(Document $document, Table $table): Table
 	{
 		$table->setHeaderTitle('App Describe');
@@ -85,11 +89,6 @@ class AppsDescribeCommand extends Command
 		]);
 
 		return $table;
-	}
-
-	protected function getOutputAsJson(ResponseInterface $response): string
-	{
-		return $response->getBody()->getContents();
 	}
 }
 

--- a/src/App/Commands/AppsDescribeCommand.php
+++ b/src/App/Commands/AppsDescribeCommand.php
@@ -3,8 +3,10 @@
 namespace Console\App\Commands;
 
 use Art4\JsonApiClient\V1\Document;
+use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Art4\JsonApiClient\Exception\ValidationException;
@@ -25,9 +27,10 @@ class AppsDescribeCommand extends Command
 	 */
 	protected function configure()
 	{
-		$this->setDescription('gets the apps you specify')
+		$this->setDescription('Gets your app description')
 			->setHelp('try rebooting')
-			->addArgument('app_id', InputArgument::REQUIRED, 'which app would you like to describe?');
+			->addArgument('app_id', InputArgument::REQUIRED, 'which app would you like to describe?')
+			->addOption('json', 'j', InputOption::VALUE_NONE, 'Output as a raw json');
 	}
 
 	/**
@@ -48,29 +51,45 @@ class AppsDescribeCommand extends Command
 			);
 		} catch (GuzzleException $guzzleException) {
 			$output->writeln($guzzleException->getMessage());
-			die();
+			exit(1);
 		}
 
 		try {
-			/** @var Document $document */
-			$document = Parser::parseResponseString($response->getBody()->getContents());
-			$table = new Table($output);
-			$table->setHeaderTitle('App Describe');
-			$table->setHeaders([
-				'Name', 'Description', 'Status', 'VCPU', 'Memory', 'Replicas',
-			]);
-			$table->addRow([
-				$document->get('data.id'),
-				$document->get('data.attributes.description'),
-				$document->get('data.attributes.status'),
-				$document->get('data.attributes.vcpu'),
-				$document->get('data.attributes.memory'),
-				$document->get('data.attributes.replicas'),
-			]);
-			$table->render();
+			if (!empty($input->getOption('json'))) {
+				$output->writeln($this->getOutputAsJson($response));
+			} else {
+				/** @var Document $document */
+				$document = Parser::parseResponseString($response->getBody()->getContents());
+				$table = $this->getOutputAsTable($document, new Table($output));
+				$table->render();
+			}
 		} catch (ValidationException $e) {
 			$output->writeln($e->getMessage());
+			exit(1);
 		}
+	}
+
+	protected function getOutputAsTable(Document $document, Table $table): Table
+	{
+		$table->setHeaderTitle('App Describe');
+		$table->setHeaders([
+			'Name', 'Description', 'Status', 'VCPU', 'Memory', 'Replicas',
+		]);
+		$table->addRow([
+			$document->get('data.id'),
+			$document->get('data.attributes.description'),
+			$document->get('data.attributes.status'),
+			$document->get('data.attributes.vcpu'),
+			$document->get('data.attributes.memory'),
+			$document->get('data.attributes.replicas'),
+		]);
+
+		return $table;
+	}
+
+	protected function getOutputAsJson(ResponseInterface $response): string
+	{
+		return $response->getBody()->getContents();
 	}
 }
 

--- a/src/App/Commands/AppsListCommand.php
+++ b/src/App/Commands/AppsListCommand.php
@@ -19,6 +19,9 @@ class AppsListCommand extends Command
 
 	const API_ENDPOINT = 'https://api.lamp.io/apps';
 
+	/**
+	 *
+	 */
 	protected function configure()
 	{
 		$this->setDescription('gets the set of apps from the org associated with your token')
@@ -26,6 +29,12 @@ class AppsListCommand extends Command
 			->addOption('json', 'j', InputOption::VALUE_NONE, 'Output as a raw json');
 	}
 
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int|null|void
+	 * @throws \Exception
+	 */
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
 		parent::execute($input, $output);
@@ -55,6 +64,11 @@ class AppsListCommand extends Command
 		}
 	}
 
+	/**
+	 * @param Document $document
+	 * @param Table $table
+	 * @return Table
+	 */
 	protected function getOutputAsTable(Document $document, Table $table): Table
 	{
 		$table->setHeaderTitle('Apps');

--- a/src/App/Commands/AppsListCommand.php
+++ b/src/App/Commands/AppsListCommand.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Art4\JsonApiClient\Exception\ValidationException;
 use Art4\JsonApiClient\Helper\Parser;
@@ -21,7 +22,8 @@ class AppsListCommand extends Command
 	protected function configure()
 	{
 		$this->setDescription('gets the set of apps from the org associated with your token')
-			->setHelp('try rebooting');
+			->setHelp('try rebooting')
+			->addOption('json', 'j', InputOption::VALUE_NONE, 'Output as a raw json');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output)
@@ -40,26 +42,35 @@ class AppsListCommand extends Command
 		}
 
 		try {
-			/** @var Document $document */
-			$document = Parser::parseResponseString($response->getBody()->getContents());
-			$serializer = new ArraySerializer(['recursive' => true]);
-			$table = new Table($output);
-			$table->setHeaderTitle('Apps');
-			$table->setHeaders(['App id', 'App description']);
-			$apps = $serializer->serialize($document);
-			foreach ($apps['data'] as $key => $app) {
-				$table->addRow([
-					$app['id'],
-					$app['attributes']['description'],
-				]);
-				if ($key != count($apps['data']) - 1) {
-					$table->addRow(new TableSeparator());
-				}
+			if (!empty($input->getOption('json'))) {
+				$output->writeln($response->getBody()->getContents());
+			} else {
+				/** @var Document $document */
+				$document = Parser::parseResponseString($response->getBody()->getContents());
+				$table = $this->getOutputAsTable($document, new Table($output));
+				$table->render();
 			}
-			$table->render();
 		} catch (ValidationException $e) {
 			$output->writeln($e->getMessage());
 		}
+	}
 
+	protected function getOutputAsTable(Document $document, Table $table): Table
+	{
+		$table->setHeaderTitle('Apps');
+		$table->setHeaders(['App id', 'App description']);
+		$serializer = new ArraySerializer(['recursive' => true]);
+		$apps = $serializer->serialize($document);
+		foreach ($apps['data'] as $key => $app) {
+			$table->addRow([
+				$app['id'],
+				$app['attributes']['description'],
+			]);
+			if ($key != count($apps['data']) - 1) {
+				$table->addRow(new TableSeparator());
+			}
+		}
+
+		return $table;
 	}
 }


### PR DESCRIPTION
Hi, 

Issue https://github.com/lamp-io/lio/issues/28

I've added [-j][--json] option to apps:list, apps:describe and files:list that will output in raw json response from your API. 

My opinion that this option should be presented only on GET commands. Please correct me if i am wrong, and i will add this option to all commands. 

(this branch has been merged with files_download branch)