### PR TITLE
Apps update

### DIFF
--- a/bin/lio
+++ b/bin/lio
@@ -16,6 +16,7 @@ use Console\App\Commands\Files\FilesListCommand;
 use Console\App\Commands\Apps\AppsDeleteCommand;
 use Console\App\Commands\Files\FilesUploadCommand;
 use Console\App\Commands\SelfUpdateCommand;
+use Console\App\Commands\Apps\AppsUpdateCommand;
 
 $app = new Application();
 $app->add(new AppsListCommand(new Client()));
@@ -26,4 +27,5 @@ $app->add(new FilesListCommand(new Client()));
 $app->add(new AppsDeleteCommand(new Client()));
 $app->add(new FilesUploadCommand(new Client()));
 $app->add(new SelfUpdateCommand());
+$app->add(new AppsUpdateCommand(new Client()));
 $app->run();

--- a/src/App/Commands/Apps/AppsNewCommand.php
+++ b/src/App/Commands/Apps/AppsNewCommand.php
@@ -44,7 +44,9 @@ class AppsNewCommand extends Command
 			->addOption('min_replicas', null, InputOption::VALUE_REQUIRED, 'The minimum number of auto-scaled replicas INT', 1)
 			->addOption(self::PHP_INI_OPTION_NAME, null, InputOption::VALUE_REQUIRED, 'Path to your php.ini', self::PHP_INI_DEFAULT)
 			->addOption('replicas', 'r', InputOption::VALUE_REQUIRED, 'The number current number replicas available. 0 stops app. INT', 1)
-			->addOption('vcpu', null, InputOption::VALUE_REQUIRED, 'The number of virtual cpu cores available (maximum: 4, minimum: 0.25) FLOAT', 0.25);
+			->addOption('vcpu', null, InputOption::VALUE_REQUIRED, 'The number of virtual cpu cores available (maximum: 4, minimum: 0.25) FLOAT', 0.25)
+			->addOption('github_webhook_secret', null, InputOption::VALUE_REQUIRED, 'Github web-hook secret token', '')
+			->addOption('webhook_run_command', null, InputOption::VALUE_REQUIRED, 'Github web-hook command', '');
 	}
 
 	/**
@@ -98,14 +100,16 @@ class AppsNewCommand extends Command
 				'attributes' =>
 					array_merge(
 						[
-							'description'  => (string)$input->getOption('description'),
-							'httpd_conf'   => $httpdConfig,
-							'max_replicas' => (int)$input->getOption('max_replicas'),
-							'memory'       => (string)$input->getOption('memory'),
-							'min_replicas' => (int)$input->getOption('min_replicas'),
-							'php_ini'      => $phpConfig,
-							'replicas'     => (int)$input->getOption('replicas'),
-							'vcpu'         => (float)$input->getOption('vcpu'),
+							'description'           => (string)$input->getOption('description'),
+							'httpd_conf'            => $httpdConfig,
+							'max_replicas'          => (int)$input->getOption('max_replicas'),
+							'memory'                => (string)$input->getOption('memory'),
+							'min_replicas'          => (int)$input->getOption('min_replicas'),
+							'php_ini'               => $phpConfig,
+							'replicas'              => (int)$input->getOption('replicas'),
+							'vcpu'                  => (float)$input->getOption('vcpu'),
+							'github_webhook_secret' => $input->getOption('github_webhook_secret'),
+							'webhook_run_command'   => $input->getOption('webhook_run_command'),
 						],
 						!empty($input->getArgument('organization_id')) ? ['organization_id' => (string)$input->getArgument('organization_id')] : []
 					),

--- a/src/App/Commands/Apps/AppsNewCommand.php
+++ b/src/App/Commands/Apps/AppsNewCommand.php
@@ -108,8 +108,8 @@ class AppsNewCommand extends Command
 							'php_ini'               => $phpConfig,
 							'replicas'              => (int)$input->getOption('replicas'),
 							'vcpu'                  => (float)$input->getOption('vcpu'),
-							'github_webhook_secret' => $input->getOption('github_webhook_secret'),
-							'webhook_run_command'   => $input->getOption('webhook_run_command'),
+							'github_webhook_secret' => (string)$input->getOption('github_webhook_secret'),
+							'webhook_run_command'   => (string)$input->getOption('webhook_run_command'),
 						],
 						!empty($input->getArgument('organization_id')) ? ['organization_id' => (string)$input->getArgument('organization_id')] : []
 					),

--- a/src/App/Commands/Apps/AppsUpdateCommand.php
+++ b/src/App/Commands/Apps/AppsUpdateCommand.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Console\App\Commands\Apps;
+
+use Console\App\Commands\Command;
+use Art4\JsonApiClient\Exception\ValidationException;
+use Art4\JsonApiClient\Helper\Parser;
+use Art4\JsonApiClient\V1\Document;
+use GuzzleHttp\Exception\GuzzleException;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class AppsUpdateCommand extends Command
+{
+	const API_ENDPOINT = 'https://api.lamp.io/apps/%s';
+
+	const HTTPD_CONF_OPTION_NAME = 'httpd_conf';
+
+	const PHP_INI_OPTION_NAME = 'php_ini';
+
+	const DEFAULT_CLI_OPTIONS = [
+		'help', 'quiet', 'verbose', 'version', 'ansi', 'no-ansi', 'no-interaction',
+	];
+
+	protected static $defaultName = 'apps:update';
+
+	/**
+	 *
+	 */
+	protected function configure()
+	{
+		$this->setDescription('Creates a new app')
+			->setHelp('Allow you to create app, api reference https://www.lamp.io/api#/apps/appsCreate')
+			->addArgument('app_id', InputArgument::REQUIRED, 'The ID of the app')
+			->addArgument('organization_id', InputArgument::OPTIONAL, 'The ID(uuid) of the organization this app belongs to. STRING')
+			->addOption('description', 'd', InputOption::VALUE_REQUIRED, 'A description', '')
+			->addOption(self::HTTPD_CONF_OPTION_NAME, null, InputOption::VALUE_REQUIRED, 'Path to your httpd.conf', '')
+			->addOption('max_replicas', null, InputOption::VALUE_REQUIRED, 'The maximum number of auto-scaled replicas INT', '')
+			->addOption('memory', 'm', InputOption::VALUE_REQUIRED, 'The amount of memory available (example: 1Gi) STRING', '')
+			->addOption('min_replicas', null, InputOption::VALUE_REQUIRED, 'The minimum number of auto-scaled replicas INT', '')
+			->addOption(self::PHP_INI_OPTION_NAME, null, InputOption::VALUE_REQUIRED, 'Path to your php.ini', '')
+			->addOption('replicas', 'r', InputOption::VALUE_REQUIRED, 'The number current number replicas available. 0 stops app. INT', '')
+			->addOption('vcpu', null, InputOption::VALUE_REQUIRED, 'The number of virtual cpu cores available (maximum: 4, minimum: 0.25) FLOAT', '')
+			->addOption('github_webhook_secret', null, InputOption::VALUE_REQUIRED, 'Github web-hook secret token', '')
+			->addOption('webhook_run_command', null, InputOption::VALUE_REQUIRED, 'Github web-hook command', '');
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int|null|void
+	 * @throws \Exception
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output)
+	{
+		parent::execute($input, $output);
+
+		try {
+			$response = $this->httpHelper->getClient()->request(
+				'PATCH',
+				sprintf(
+					self::API_ENDPOINT,
+					$input->getArgument('app_id')
+					),
+				[
+					'headers' => $this->httpHelper->getHeaders(),
+					'body'    => $this->getRequestBody($input),
+				]
+			);
+		} catch (GuzzleException $guzzleException) {
+			$output->writeln($guzzleException->getMessage());
+			exit(1);
+		} catch (\InvalidArgumentException $invalidArgumentException) {
+			$output->writeln($invalidArgumentException->getMessage());
+			exit(1);
+		}
+
+		try {
+			/** @var Document $document */
+			$document = Parser::parseResponseString($response->getBody()->getContents());
+			$output->writeln('Your app' . $document->get('data.id') .  'successfully updated');
+		} catch (ValidationException $e) {
+			$output->writeln($e->getMessage());
+			exit(1);
+		}
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @return string
+	 */
+	protected function getRequestBody(InputInterface $input): string
+	{
+		$attributes = [];
+		foreach ($input->getOptions() as $optionKey => $optionValue) {
+			if (!in_array($optionKey, self::DEFAULT_CLI_OPTIONS) && !empty($input->getOption($optionKey))) {
+				if ($optionKey == self::HTTPD_CONF_OPTION_NAME || $optionKey == self::PHP_INI_OPTION_NAME) {
+					$attributes[$optionKey] = $this->parseConfigFilesOptions($optionKey, $input);
+				} else {
+					$attributes[$optionKey] = $optionValue;
+				}
+			}
+		}
+
+		$attributes = array_merge($attributes,
+			!empty($input->getArgument('organization_id')) ? ['organization_id' => (string)$input->getArgument('organization_id')] : []
+		);
+
+		return json_encode([
+			'data' => [
+				'attributes' => $attributes,
+				'id'         => $input->getArgument('app_id'),
+				'type'       => 'apps',
+			],
+		]);
+	}
+
+	/**
+	 * @param string $optionName
+	 * @param InputInterface $input
+	 * @return string
+	 */
+	protected function parseConfigFilesOptions(string $optionName, InputInterface $input): string
+	{
+		if (!file_exists($input->getOption($optionName))) {
+			throw new InvalidArgumentException('File ' . $optionName . ' not exist, path: ' . $input->getOption($optionName));
+		}
+		$config = file_get_contents($input->getOption($optionName));
+
+		return $config;
+	}
+}

--- a/src/App/Commands/Apps/AppsUpdateCommand.php
+++ b/src/App/Commands/Apps/AppsUpdateCommand.php
@@ -81,7 +81,7 @@ class AppsUpdateCommand extends Command
 		try {
 			/** @var Document $document */
 			$document = Parser::parseResponseString($response->getBody()->getContents());
-			$output->writeln('Your app' . $document->get('data.id') .  'successfully updated');
+			$output->writeln('Your app ' . $document->get('data.id') .  ' successfully updated');
 		} catch (ValidationException $e) {
 			$output->writeln($e->getMessage());
 			exit(1);


### PR DESCRIPTION
Hi, 

I've implemented apps:update command 
API endpoint: https://www.lamp.io/api#/apps/appsUpdate

Usage: apps:update <app_id> <organization_id> [-d][--description] [--httpd_conf] [--max_replicas] [-m][--memory] [--min_replicas] [--php_ini] [-r][--replicas] [--vcpu]

Updated `apps:new` command with new body params (`github_webhook_secret` and `webhook_run_command`)
And updated directory structure (now `apps`, `files` and others commands will have own subfolders) 