### PR TITLE
Databases fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Commands
     
 ### Databases 
 
-1. ### databases:new  [-d][--description] [-m][--memory] [--organization_id] [--my_cnf] [--mysql_root_password] [--ssd] [--vcpu]
+1. ### databases:new  [-d][--description] [-m][--memory] [--organization_id] [--my_cnf] [--ssd] [--vcpu]
 
    Create a new database
     
@@ -203,7 +203,6 @@ Commands
    * `[-m][--memory](string){512Mi}` Amount of virtual memory on your database
    * `[--organization_id](string)` Name of your organization
    * `[--my_cnf](string)` Path to your database config file
-   * `[--mysql_root_password](string)` Root password
    * `[--ssd](string){1Gi}` Size of ssd storage
    * `[--vcpu](float){0.25}` The number of virtual cpu cores available, default 0.25
    
@@ -229,7 +228,7 @@ Commands
    * `[-m][--memory](string)` Amount of virtual memory on your database
    * `[--organization_id](string)` Name of your organization
    * `[--my_cnf](string)` Path to your database config file
-   * `[--mysql_root_password](string)` Root password
+   * `[--mysql_root_password](bool)` If you need to update root password, set it as true
    * `[--ssd](string)` Size of ssd storage
    * `[--vcpu](float)` The number of virtual cpu cores available, default 0.25
     

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Commands
     
 4. #### apps:update <app_id> <organization_id>  [-d][--description] [--httpd_conf] [--max_replicas] [-m][--memory] [--min_replicas] [--php_ini] [-r][--replicas] [--vcpu]
     
-    Will allow you to update selected app
+    Will allow you to update selected app. Command should be executed with at least one option
     
     Arguments:
     
@@ -217,7 +217,7 @@ Commands
     
 3. ### databases:update <database_id> [-d][--description] [-m][--memory] [--organization_id] [--my_cnf] [--mysql_root_password] [--ssd] [--vcpu]
     
-    Update a database
+    Update a database. Command should be executed with at least one option
     
     Arguments:
         

--- a/src/App/Commands/Apps/AppsDeleteCommand.php
+++ b/src/App/Commands/Apps/AppsDeleteCommand.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Console\App\Commands\Command;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Helper\QuestionHelper;
 
 class AppsDeleteCommand extends Command
 {
@@ -35,7 +37,12 @@ class AppsDeleteCommand extends Command
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
 		parent::execute($input, $output);
-
+		/** @var QuestionHelper $helper */
+		$helper = $this->getHelper('question');
+		$question = new ConfirmationQuestion('<info>Are you sure you want to delete database? (y/N)</info>', false);
+		if (!$helper->ask($input, $output, $question)) {
+			exit(0);
+		}
 		try {
 			$this->httpHelper->getClient()->request(
 				'DELETE',

--- a/src/App/Commands/Apps/AppsUpdateCommand.php
+++ b/src/App/Commands/Apps/AppsUpdateCommand.php
@@ -147,7 +147,7 @@ class AppsUpdateCommand extends Command
 					return '--' . $key;
 				}
 			}, ARRAY_FILTER_USE_KEY);
-			$output->writeln('<comment>Command requires at least one option to be executed. List of allowed options:' . implode(PHP_EOL, array_keys($commandOptions)) . '</comment>');
+			$output->writeln('<comment>Command requires at least one option to be executed. List of allowed options:' . PHP_EOL . implode(PHP_EOL, array_keys($commandOptions)) . '</comment>');
 			exit(1);
 		}
 

--- a/src/App/Commands/Apps/AppsUpdateCommand.php
+++ b/src/App/Commands/Apps/AppsUpdateCommand.php
@@ -6,12 +6,14 @@ use Console\App\Commands\Command;
 use Art4\JsonApiClient\Exception\ValidationException;
 use Art4\JsonApiClient\Helper\Parser;
 use Art4\JsonApiClient\V1\Document;
+use Symfony\Component\Console\Helper\Table;
 use GuzzleHttp\Exception\GuzzleException;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Art4\JsonApiClient\Serializer\ArraySerializer;
 
 class AppsUpdateCommand extends Command
 {
@@ -20,6 +22,10 @@ class AppsUpdateCommand extends Command
 	const HTTPD_CONF_OPTION_NAME = 'httpd_conf';
 
 	const PHP_INI_OPTION_NAME = 'php_ini';
+
+	const EXCLUDE_FROM_OUTPUT = [
+		'ssh_pub_key',
+	];
 
 	protected static $defaultName = 'apps:update';
 
@@ -32,7 +38,7 @@ class AppsUpdateCommand extends Command
 		$this->setDescription('Creates a new app')
 			->setHelp('Allow you to create app, api reference https://www.lamp.io/api#/apps/appsCreate')
 			->addArgument('app_id', InputArgument::REQUIRED, 'The ID of the app')
-			->addArgument('organization_id', InputArgument::OPTIONAL, 'The ID(uuid) of the organization this app belongs to. STRING')
+			->addOption('organization_id', null, InputOption::VALUE_REQUIRED, 'The ID(uuid) of the organization this app belongs to. STRING')
 			->addOption('description', 'd', InputOption::VALUE_REQUIRED, 'A description', '')
 			->addOption(self::HTTPD_CONF_OPTION_NAME, null, InputOption::VALUE_REQUIRED, 'Path to your httpd.conf', '')
 			->addOption('max_replicas', null, InputOption::VALUE_REQUIRED, 'The maximum number of auto-scaled replicas INT', '')
@@ -61,10 +67,10 @@ class AppsUpdateCommand extends Command
 				sprintf(
 					self::API_ENDPOINT,
 					$input->getArgument('app_id')
-					),
+				),
 				[
 					'headers' => $this->httpHelper->getHeaders(),
-					'body'    => $this->getRequestBody($input),
+					'body'    => $this->getRequestBody($input, $output),
 				]
 			);
 		} catch (GuzzleException $guzzleException) {
@@ -76,9 +82,14 @@ class AppsUpdateCommand extends Command
 		}
 
 		try {
-			/** @var Document $document */
-			$document = Parser::parseResponseString($response->getBody()->getContents());
-			$output->writeln('Your app ' . $document->get('data.id') .  ' successfully updated');
+			if (!empty($input->getOption('json'))) {
+				$output->writeln($response->getBody()->getContents());
+			} else {
+				/** @var Document $document */
+				$document = Parser::parseResponseString($response->getBody()->getContents());
+				$table = $this->getOutputAsTable($document, new Table($output));
+				$table->render();
+			}
 		} catch (ValidationException $e) {
 			$output->writeln($e->getMessage());
 			exit(1);
@@ -86,25 +97,54 @@ class AppsUpdateCommand extends Command
 	}
 
 	/**
+	 * @param Document $document
+	 * @param Table $table
+	 * @return Table
+	 */
+	protected function getOutputAsTable(Document $document, Table $table): Table
+	{
+		$table->setHeaderTitle('App');
+		$serializer = new ArraySerializer(['recursive' => true]);
+		$serializedDocument = $serializer->serialize($document);
+		$headers = ['Id', 'Attributes'];
+		$row = [$serializedDocument['data']['id']];
+		$attributes = [];
+		foreach ($serializedDocument['data']['attributes'] as $key => $attribute) {
+			if (!empty($attribute) && !in_array($key, self::EXCLUDE_FROM_OUTPUT)) {
+				$attributes[] = $key . ' : ' . trim(preg_replace(
+						'/\s\s+|\t/', ' ', wordwrap($attribute, 40)
+					));
+			}
+		}
+		$row[] = implode(PHP_EOL, $attributes);
+		$table->setHeaders($headers);
+		$table->addRow($row);
+		return $table;
+	}
+
+
+	/**
 	 * @param InputInterface $input
+	 * @param OutputInterface $output
 	 * @return string
 	 */
-	protected function getRequestBody(InputInterface $input): string
+	protected function getRequestBody(InputInterface $input, OutputInterface $output): string
 	{
 		$attributes = [];
-		foreach ($input->getOptions() as $optionKey => $optionValue) {
-			if (!in_array($optionKey, self::DEFAULT_CLI_OPTIONS) && !empty($input->getOption($optionKey))) {
-				if ($optionKey == self::HTTPD_CONF_OPTION_NAME || $optionKey == self::PHP_INI_OPTION_NAME) {
-					$attributes[$optionKey] = $this->parseConfigFilesOptions($optionKey, $input);
+		foreach ($input->getOptions() as $key => $option) {
+			if (!in_array($key, self::DEFAULT_CLI_OPTIONS) && !empty($option)) {
+				if ($key == self::HTTPD_CONF_OPTION_NAME || $key == self::PHP_INI_OPTION_NAME) {
+					$this->validateConfigFilesOptions($key, $input);
+					$attributes[$key] = file_get_contents($option);
 				} else {
-					$attributes[$optionKey] = $optionValue;
+					$attributes[$key] = $option;
 				}
 			}
 		}
-
-		$attributes = array_merge($attributes,
-			!empty($input->getArgument('organization_id')) ? ['organization_id' => (string)$input->getArgument('organization_id')] : []
-		);
+		if (empty($attributes)) {
+			$output->writeln('<error>Command requires at least one option to be executed</error>');
+			exit(1);
+		}
 
 		return json_encode([
 			'data' => [
@@ -118,15 +158,11 @@ class AppsUpdateCommand extends Command
 	/**
 	 * @param string $optionName
 	 * @param InputInterface $input
-	 * @return string
 	 */
-	protected function parseConfigFilesOptions(string $optionName, InputInterface $input): string
+	protected function validateConfigFilesOptions(string $optionName, InputInterface $input)
 	{
 		if (!file_exists($input->getOption($optionName))) {
 			throw new InvalidArgumentException('File ' . $optionName . ' not exist, path: ' . $input->getOption($optionName));
 		}
-		$config = file_get_contents($input->getOption($optionName));
-
-		return $config;
 	}
 }

--- a/src/App/Commands/Apps/AppsUpdateCommand.php
+++ b/src/App/Commands/Apps/AppsUpdateCommand.php
@@ -142,7 +142,12 @@ class AppsUpdateCommand extends Command
 			}
 		}
 		if (empty($attributes)) {
-			$output->writeln('<error>Command requires at least one option to be executed</error>');
+			$commandOptions = array_filter($input->getOptions(), function ($key) {
+				if (!in_array($key, self::DEFAULT_CLI_OPTIONS)) {
+					return '--' . $key;
+				}
+			}, ARRAY_FILTER_USE_KEY);
+			$output->writeln('<comment>Command requires at least one option to be executed. List of allowed options:' . implode(PHP_EOL, array_keys($commandOptions)) . '</comment>');
 			exit(1);
 		}
 

--- a/src/App/Commands/Databases/DatabasesDeleteCommand.php
+++ b/src/App/Commands/Databases/DatabasesDeleteCommand.php
@@ -7,9 +7,11 @@ use Console\App\Commands\Command;
 use Exception;
 use GuzzleHttp\Exception\GuzzleException;
 use InvalidArgumentException;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class DatabasesDeleteCommand extends Command
 {
@@ -37,6 +39,12 @@ class DatabasesDeleteCommand extends Command
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
 		parent::execute($input, $output);
+		/** @var QuestionHelper $helper */
+		$helper = $this->getHelper('question');
+		$question = new ConfirmationQuestion('<info>Are you sure you want to delete database? (y/N)</info>', false);
+		if (!$helper->ask($input, $output, $question)) {
+			exit(0);
+		}
 		try {
 			$this->httpHelper->getClient()->request(
 				'DELETE',

--- a/src/App/Commands/Databases/DatabasesDescribeCommand.php
+++ b/src/App/Commands/Databases/DatabasesDescribeCommand.php
@@ -84,7 +84,9 @@ class DatabasesDescribeCommand extends Command
 		$row = [$document->get('data.id')];
 		foreach ($serializer->serialize($document)['data']['attributes'] as $attributeKey => $attribute) {
 			array_push(
-				$row, ($attributeKey != 'my_cnf') ? $attribute : wordwrap($attribute, 30)
+				$row, ($attributeKey != 'my_cnf') ? $attribute : trim(preg_replace(
+				'/\s\s+|\t/', ' ', wordwrap($attribute, 40)
+			))
 			);
 			array_push($headers, $attributeKey);
 		}

--- a/src/App/Commands/Databases/DatabasesListCommand.php
+++ b/src/App/Commands/Databases/DatabasesListCommand.php
@@ -91,20 +91,25 @@ class DatabasesListCommand extends Command
 			$row = [$data['id']];
 			$attributeArray = [];
 			foreach ($data['attributes'] as $attributeKey => $attribute) {
-				if ($attributeKey != 'my_cnf') {
-					$attributeArray[] = $attributeKey . ' : ' . wordwrap($attribute, 50);
+				if ($attributeKey == 'my_cnf' && !empty($attribute)) {
+					$mysqlConfig = $attributeKey . ' : ' . trim(preg_replace(
+							'/\s\s+|\t/', ' ', wordwrap($attribute, 40)
+						));
 				} else {
 					$attributeArray[] = $attributeKey . ' : ' . $attribute;
 				}
 			}
-			$row[] = (implode(PHP_EOL, $attributeArray));
+			$attributes = implode(PHP_EOL, $attributeArray);
+			$attributes .= !empty($mysqlConfig) ? PHP_EOL . $mysqlConfig : '';
+			unset($mysqlConfig);
+			$row[] = $attributes;
 			$table->addRow($row);
 			if ($key != count($serializedDocument['data']) - 1) {
 				$table->addRow(new TableSeparator());
 			}
 
 		}
-		$table->setColumnWidth(1, 200);
+
 		return $table;
 
 	}

--- a/src/App/Commands/Databases/DatabasesUpdateCommand.php
+++ b/src/App/Commands/Databases/DatabasesUpdateCommand.php
@@ -15,6 +15,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Question\Question;
+use Exception;
 
 class DatabasesUpdateCommand extends Command
 {
@@ -24,6 +27,7 @@ class DatabasesUpdateCommand extends Command
 
 	const EXCLUDE_FROM_OUTPUT = [
 		'my_cnf',
+		'mysql_root_password',
 	];
 
 	/**
@@ -39,7 +43,7 @@ class DatabasesUpdateCommand extends Command
 			->addOption('memory', 'm', InputOption::VALUE_REQUIRED, 'Amount of virtual memory on your database')
 			->addOption('organization_id', null, InputOption::VALUE_REQUIRED, 'Name of your organization')
 			->addOption('my_cnf', null, InputOption::VALUE_REQUIRED, 'Path to your database config file')
-			->addOption('mysql_root_password', null, InputOption::VALUE_REQUIRED, 'Root password')
+			->addOption('mysql_root_password', null, InputOption::VALUE_NONE, 'Root password')
 			->addOption('ssd', null, InputOption::VALUE_REQUIRED, 'Size of ssd storage')
 			->addOption('vcpu', null, InputOption::VALUE_REQUIRED, 'The number of virtual cpu cores available');
 	}
@@ -53,7 +57,32 @@ class DatabasesUpdateCommand extends Command
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
 		parent::execute($input, $output);
+		if ($input->getOption('mysql_root_password')) {
+			/** @var QuestionHelper $helper */
+			$helper = $this->getHelper('question');
+			$question = new Question('<info>Please write your root_password for database</info>');
+			$question->setHidden(true);
+			$question->setValidator(function ($value) {
+				$uppercase = preg_match('@[A-Z]@', $value);
+				$lowercase = preg_match('@[a-z]@', $value);
+				$number = preg_match('@[0-9]@', $value);
+				$length = strlen($value) >= 15;
+				if (!$uppercase || !$lowercase || !$number || !$length) {
+					$exceptionMessage = [
+						'* Must be a minimum of 15 characters',
+						'* Must contain at least 1 number',
+						'* Must contain at least one uppercase character',
+						'* Must contain at least one lowercase character',
+					];
+					throw new Exception(PHP_EOL . implode(PHP_EOL, $exceptionMessage));
+				}
 
+				return $value;
+			});
+			$question->setMaxAttempts(10);
+			$password = $helper->ask($input, $output, $question);
+			$input->setOption('mysql_root_password', $password);
+		}
 		try {
 			$response = $this->httpHelper->getClient()->request(
 				'PATCH',

--- a/src/App/Commands/Databases/DatabasesUpdateCommand.php
+++ b/src/App/Commands/Databases/DatabasesUpdateCommand.php
@@ -124,42 +124,12 @@ class DatabasesUpdateCommand extends Command
 		}, ARRAY_FILTER_USE_BOTH);
 
 		if (empty($body['data']['attributes'])) {
-			$body['data']['attributes'] = $this->handleEmptyAttrRequest($input, $output);
+			$output->writeln('<error>Command requires at least one option to be executed</error>');
+			exit(1);
 		}
 
 		return json_encode($body);
 	}
-
-	/**
-	 * @param InputInterface $input
-	 * @param OutputInterface $output
-	 * @return array
-	 * @throws \Exception
-	 */
-	protected function handleEmptyAttrRequest(InputInterface $input, OutputInterface $output): array
-	{
-		/** @var QuestionHelper $questionHelper */
-		$questionHelper = $this->getHelper('question');
-		$question = new ConfirmationQuestion('<info>An update with no changes will restart your database, are you sure? (Y/n)</info>');
-		if (!$questionHelper->ask($input, $output, $question)) {
-			$output->writeln("<info>Please add options and re-run command</info>");
-			exit();
-		}
-
-		$appsNewCommand = $this->getApplication()->find(DatabasesDescribeCommand::getDefaultName());
-		$args = [
-			'command'     => DatabasesDescribeCommand::getDefaultName(),
-			'database_id' => $input->getArgument('database_id'),
-			'--json'      => true,
-		];
-		$bufferedOutput = new BufferedOutput();
-		$appsNewCommand->run(new ArrayInput($args), $bufferedOutput);
-		/** @var Document $document */
-		$document = Parser::parseResponseString($bufferedOutput->fetch());
-		return ['description' => $document->get('data.attributes.description')];
-
-	}
-
 
 	/**
 	 * @param Document $document

--- a/src/App/Commands/Databases/DatabasesUpdateCommand.php
+++ b/src/App/Commands/Databases/DatabasesUpdateCommand.php
@@ -143,7 +143,7 @@ class DatabasesUpdateCommand extends Command
 					return '--' . $key;
 				}
 			}, ARRAY_FILTER_USE_KEY);
-			$output->writeln('<comment>Command requires at least one option to be executed. List of allowed options:' . implode(PHP_EOL, array_keys($commandOptions)) . '</comment>');
+			$output->writeln('<comment>Command requires at least one option to be executed. List of allowed options:' . PHP_EOL . implode(PHP_EOL, array_keys($commandOptions)) . '</comment>');
 			exit(1);
 		}
 

--- a/src/App/Commands/Databases/DatabasesUpdateCommand.php
+++ b/src/App/Commands/Databases/DatabasesUpdateCommand.php
@@ -138,7 +138,12 @@ class DatabasesUpdateCommand extends Command
 		}
 
 		if (empty($attributes)) {
-			$output->writeln('<error>Command requires at least one option to be executed</error>');
+			$commandOptions = array_filter($input->getOptions(), function ($key) {
+				if (!in_array($key, self::DEFAULT_CLI_OPTIONS)) {
+					return '--' . $key;
+				}
+			}, ARRAY_FILTER_USE_KEY);
+			$output->writeln('<comment>Command requires at least one option to be executed. List of allowed options:' . implode(PHP_EOL, array_keys($commandOptions)) . '</comment>');
 			exit(1);
 		}
 


### PR DESCRIPTION
Hi, 

Fixed,  https://github.com/lamp-io/lio/issues/50

Done, https://github.com/lamp-io/lio/issues/51 (did same for apps:update command)

Done https://github.com/lamp-io/lio/issues/52 (did same for apps:delete command)

https://github.com/lamp-io/lio/issues/53 and https://github.com/lamp-io/lio/issues/54 
Removed password from output. 
For databases:new 
When command will be executed, user should prompt his password (i've set hidden input for it, and validation rules: '* Must be a minimum of 15 characters','* Must contain at least 1 number','* Must contain at least one uppercase character','* Must contain at least one lowercase character')
For databases:update 
if option --mysql_root_password will be set, user will be asked to prompt password (same rules that on databases:new)