### PR TITLE
Convert app run to deleteFile

### DIFF
--- a/src/App/Deployers/Laravel.php
+++ b/src/App/Deployers/Laravel.php
@@ -114,11 +114,12 @@ class Laravel extends DeployerAbstract
 				'execute' => function (string $message) use ($dirs) {
 					foreach ($dirs as $dir) {
 						if (file_exists($this->appPath . $dir)) {
-							$this->appRunCommand(
-								$this->config['app']['id'],
-								'rm -rf ' . $this->releaseFolder . rtrim($dir, '/') . '/',
-								sprintf($message, $dir)
-							);
+							try {
+								$this->deleteFile($this->releaseFolder . rtrim($dir, '/'), sprintf($message, $dir));
+							} catch (ClientException $clientException) {
+								$this->consoleOutput->write(PHP_EOL);
+								return;
+							}
 						}
 					}
 				},

--- a/src/App/Deployers/Laravel.php
+++ b/src/App/Deployers/Laravel.php
@@ -114,12 +114,7 @@ class Laravel extends DeployerAbstract
 				'execute' => function (string $message) use ($dirs) {
 					foreach ($dirs as $dir) {
 						if (file_exists($this->appPath . $dir)) {
-							try {
-								$this->deleteFile($this->releaseFolder . rtrim($dir, '/'), sprintf($message, $dir));
-							} catch (ClientException $clientException) {
-								$this->consoleOutput->write(PHP_EOL);
-								return;
-							}
+							$this->deleteFile($this->releaseFolder . rtrim($dir, '/'), sprintf($message, $dir));
 						}
 					}
 				},


### PR DESCRIPTION
Issue #126 was happening because the previous command deleted the `storage` directory and there was a race condition since the next command relied on that directory being deleted.

I tested this by changing the existing `appRunCommand` to include `&& sync` which resolved the issue. However, the underlying issue is that when deleting a file using `api.lamp.io` no `sync` was performed. So, I updated the file's `DELETE` endpoint to perform the `sync` after delete. So now `deleteFile` is safe to use.