### PR TITLE
Phar artifact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,31 @@
 language: php
-
 dist: trusty
-
-matrix:
+sudo: false
+stages:
+  - name: test
+  - name: deploy
+    if: tag IS present
+jobs:
   include:
     - php: 7.2
+      before_script: composer install --dev
     - php: 7.3
-    - php: 7.3
-    - php: nightly
+      before_script: composer install --dev
     - php: 7.4snapshot
-    - deploy:
-        name: deploy
-        php: 7.3
-        script: composer build
+      before_script: composer install --dev
+    - php: nightly
+      before_script: composer install --dev
+    - stage: deploy
+      script: composer build
+      before_script: composer install
+      php: 7.3
+      deploy:
         provider: releases
         api_key: $GITHUB_TOKEN
         file: build/lio.phar
         skip_cleanup: true
         on:
-          branch: phar_artifact
-  fast_finish: true
+          tags: true
   allow_failures:
     - php: nightly
     - php: 7.4snapshot
-
-before_script:
-  - composer install --dev
-
-script:
-  - ./vendor/bin/phpunit
-
-before_deploy:
-  - composer build

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,19 @@ script:
 before_deploy:
   - composer build
 
-deploy:
-  provider: releases
-  api_key: $GITHUB_TOKEN
-  file: build/lio.phar
-  skip_cleanup: true
-  on:
-    branch: phar_artifact
+jobs:
+  include:
+    - stage: deploy
+      php: 7.3
+      provider: releases
+      file: build/lio.phar
+        skip_cleanup: true
+        on:
+          branch: phar_artifact
+#deploy:
+#  provider: releases
+#  api_key: $GITHUB_TOKEN
+#  file: build/lio.phar
+#  skip_cleanup: true
+#  on:
+#    branch: phar_artifact

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,14 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit
+
+before_deploy:
+  - composer build
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  file: build/lio.phar
+  skip_cleanup: true
+  on:
+    branch: phar_artifact

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
         skip_cleanup: true
         on:
           tags: true
+        name: $TRAVIS_TAG
   allow_failures:
     - php: nightly
     - php: 7.4snapshot

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,14 @@ matrix:
     - php: 7.3
     - php: nightly
     - php: 7.4snapshot
+    - deploy:
+        script: composer build
+        provider: releases
+        api_key: $GITHUB_TOKEN
+        file: build/lio.phar
+        skip_cleanup: true
+        on:
+          branch: phar_artifact
   fast_finish: true
   allow_failures:
     - php: nightly
@@ -23,15 +31,6 @@ script:
 before_deploy:
   - composer build
 
-jobs:
-  include:
-    - stage: deploy
-      php: 7.3
-      provider: releases
-      file: build/lio.phar
-        skip_cleanup: true
-        on:
-          branch: phar_artifact
 #deploy:
 #  provider: releases
 #  api_key: $GITHUB_TOKEN
@@ -39,3 +38,4 @@ jobs:
 #  skip_cleanup: true
 #  on:
 #    branch: phar_artifact
+#    php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     - php: nightly
     - php: 7.4snapshot
     - deploy:
+        name: deploy
+        php: 7.3
         script: composer build
         provider: releases
         api_key: $GITHUB_TOKEN
@@ -30,12 +32,3 @@ script:
 
 before_deploy:
   - composer build
-
-#deploy:
-#  provider: releases
-#  api_key: $GITHUB_TOKEN
-#  file: build/lio.phar
-#  skip_cleanup: true
-#  on:
-#    branch: phar_artifact
-#    php: 7.3

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ composer require lamp-il/lio
 ```
 
 ##### Download as a PHAR
-[lio.phar]()
+[lio.phar](https://github.com/lamp-io/lio/releases/latest/download/lio.phar)
 
 Usage
 ------------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ composer global require lamp-io/lio
 
 ##### As local composer package
 ```sh
-composer require lamp-il/lio
+composer require lamp-io/lio
 ```
 
 ##### Download as a PHAR

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
   "require-dev": {
     "phpunit/phpunit": "^8.3"
   },
-  "version": "0.1.0",
   "autoload": {
     "psr-4": {
       "Lio\\": "src"


### PR DESCRIPTION
Hi 

Issue #149 

Now all tagged commits will automatically create release, and attache to it phar 
(on readme.md the link to phar will always go to latest release phar version)

![Screenshot from 2019-10-09 11-45-14](https://user-images.githubusercontent.com/46731109/66465821-46757500-ea8a-11e9-87f6-5d7177b4f7a9.png)
